### PR TITLE
migrated the PipelinesApiPathsSpec test to batch

### DIFF
--- a/supportedBackends/google/pipelines/batch/src/test/scala/cromwell/backend/google/pipelines/batch/GcpBatchCallPathsSpec.scala
+++ b/supportedBackends/google/pipelines/batch/src/test/scala/cromwell/backend/google/pipelines/batch/GcpBatchCallPathsSpec.scala
@@ -16,64 +16,64 @@ class GcpBatchCallPathsSpec extends TestKitSuite with AnyFlatSpecLike with Match
 
   behavior of "JesCallPaths"
 
-  it should "map the correct filenames" in {
-//    val workflowDescriptor = buildWdlWorkflowDescriptor(
-//      SampleWdl.HelloWorld.workflowSource(),
-//      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
-//    )
-//    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-//
-//    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
-//    val workflowPaths = GcpBatchWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), batchConfiguration, pathBuilders(), GcpBatchInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
-//
-//    val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
-//
-//    callPaths.returnCodeFilename should be("rc")
-//    callPaths.stderr.getFileName.pathAsString should be("gs://my-cromwell-workflows-bucket/stderr")
-//    callPaths.stdout.getFileName.pathAsString should be("gs://my-cromwell-workflows-bucket/stdout")
-//    callPaths.jesLogFilename should be("hello.log")
+  it should "map the correct filenames" in (pending) {
+    val workflowDescriptor = buildWdlWorkflowDescriptor(
+      SampleWdl.HelloWorld.workflowSource(),
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+    )
+    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+
+    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
+    val workflowPaths = GcpBatchWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), batchConfiguration, pathBuilders(), GcpBatchInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
+
+    val callPaths = GcpBatchJobPaths(workflowPaths, jobDescriptorKey)
+
+    callPaths.returnCodeFilename should be("rc")
+    callPaths.stderr.getFileName.pathAsString should be("gs://my-cromwell-workflows-bucket/stderr")
+    callPaths.stdout.getFileName.pathAsString should be("gs://my-cromwell-workflows-bucket/stdout")
+    callPaths.jesLogFilename should be("hello.log")
   }
 
-  it should "map the correct paths" in {
-//    val workflowDescriptor = buildWdlWorkflowDescriptor(
-//      SampleWdl.HelloWorld.workflowSource(),
-//      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
-//    )
-//    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-//
-//    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
-//    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders(), PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
-//
-//    val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
-//
-//    callPaths.returnCode.pathAsString should
-//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/rc")
-//    callPaths.stdout.pathAsString should
-//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stdout")
-//    callPaths.stderr.pathAsString should
-//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stderr")
-//    callPaths.jesLogPath.pathAsString should
-//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/hello.log")
+  it should "map the correct paths" in (pending) {
+    val workflowDescriptor = buildWdlWorkflowDescriptor(
+      SampleWdl.HelloWorld.workflowSource(),
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+    )
+    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+
+    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
+    val workflowPaths = GcpBatchWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), batchConfiguration, pathBuilders(), GcpBatchInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
+
+    val callPaths = GcpBatchJobPaths(workflowPaths, jobDescriptorKey)
+
+    callPaths.returnCode.pathAsString should
+      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/rc")
+    callPaths.stdout.pathAsString should
+      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stdout")
+    callPaths.stderr.pathAsString should
+      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stderr")
+    callPaths.jesLogPath.pathAsString should
+      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/hello.log")
   }
 
-  it should "map the correct call context" in {
-//    val workflowDescriptor = buildWdlWorkflowDescriptor(
-//      SampleWdl.HelloWorld.workflowSource(),
-//      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
-//    )
-//    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-//
-//    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
-//    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders(), PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
-//
-//    val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
-//
-//    callPaths.callContext.root.pathAsString should
-//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello")
-//    callPaths.callContext.stdout should
-//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stdout")
-//    callPaths.callContext.stderr should
-//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stderr")
+  it should "map the correct call context" in (pending) {
+    val workflowDescriptor = buildWdlWorkflowDescriptor(
+      SampleWdl.HelloWorld.workflowSource(),
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+    )
+    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+
+    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
+    val workflowPaths = GcpBatchWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), batchConfiguration, pathBuilders(), GcpBatchInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
+
+    val callPaths = GcpBatchJobPaths(workflowPaths, jobDescriptorKey)
+
+    callPaths.callContext.root.pathAsString should
+      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello")
+    callPaths.callContext.stdout should
+      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stdout")
+    callPaths.callContext.stderr should
+      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stderr")
   }
 
 }

--- a/supportedBackends/google/pipelines/batch/src/test/scala/cromwell/backend/google/pipelines/batch/GcpBatchCallPathsSpec.scala
+++ b/supportedBackends/google/pipelines/batch/src/test/scala/cromwell/backend/google/pipelines/batch/GcpBatchCallPathsSpec.scala
@@ -1,0 +1,79 @@
+package cromwell.backend.google.pipelines.batch
+
+import com.google.cloud.NoCredentials
+import common.collections.EnhancedCollections._
+import cromwell.backend.BackendSpec
+import cromwell.backend.google.pipelines.batch.GcpBatchTestConfig.{batchConfiguration, pathBuilders}
+import cromwell.core.TestKitSuite
+import cromwell.util.SampleWdl
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import spray.json.{JsObject, JsString}
+
+class GcpBatchCallPathsSpec extends TestKitSuite with AnyFlatSpecLike with Matchers {
+
+  import BackendSpec._
+
+  behavior of "JesCallPaths"
+
+  it should "map the correct filenames" in {
+//    val workflowDescriptor = buildWdlWorkflowDescriptor(
+//      SampleWdl.HelloWorld.workflowSource(),
+//      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+//    )
+//    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+//
+//    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
+//    val workflowPaths = GcpBatchWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), batchConfiguration, pathBuilders(), GcpBatchInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
+//
+//    val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
+//
+//    callPaths.returnCodeFilename should be("rc")
+//    callPaths.stderr.getFileName.pathAsString should be("gs://my-cromwell-workflows-bucket/stderr")
+//    callPaths.stdout.getFileName.pathAsString should be("gs://my-cromwell-workflows-bucket/stdout")
+//    callPaths.jesLogFilename should be("hello.log")
+  }
+
+  it should "map the correct paths" in {
+//    val workflowDescriptor = buildWdlWorkflowDescriptor(
+//      SampleWdl.HelloWorld.workflowSource(),
+//      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+//    )
+//    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+//
+//    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
+//    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders(), PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
+//
+//    val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
+//
+//    callPaths.returnCode.pathAsString should
+//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/rc")
+//    callPaths.stdout.pathAsString should
+//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stdout")
+//    callPaths.stderr.pathAsString should
+//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stderr")
+//    callPaths.jesLogPath.pathAsString should
+//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/hello.log")
+  }
+
+  it should "map the correct call context" in {
+//    val workflowDescriptor = buildWdlWorkflowDescriptor(
+//      SampleWdl.HelloWorld.workflowSource(),
+//      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+//    )
+//    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+//
+//    // TODO: review if the method defaultStandardStreamNameToFileNameMetadataMapper is required in the initialization actor
+//    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders(), PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
+//
+//    val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
+//
+//    callPaths.callContext.root.pathAsString should
+//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello")
+//    callPaths.callContext.stdout should
+//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stdout")
+//    callPaths.callContext.stderr should
+//      be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stderr")
+  }
+
+}


### PR DESCRIPTION
Please review if the defaultStandardStreamNameToFileNameMetadataMapper method is required in our gcp batch initialization actor. Tests have been commented out.