### PR TITLE
Fix Gcp Batch RunStatus

### DIFF
--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -25,7 +25,7 @@ import cats.data.NonEmptyList
 import common.validation.ErrorOr.ErrorOr
 import cromwell.backend.async.{ExecutionHandle, PendingExecutionHandle}
 import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.GcsTransferConfiguration
-import cromwell.backend.google.pipelines.batch.RunStatus.{Succeeded, TerminalRunStatus}
+import cromwell.backend.google.pipelines.batch.RunStatus.TerminalRunStatus
 import cromwell.backend.google.pipelines.common.WorkflowOptionKeys
 import cromwell.core.io.IoCommandBuilder
 import cromwell.core.path.DefaultPathBuilder
@@ -976,8 +976,10 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
 
   override def getTerminalEvents(runStatus: RunStatus): Seq[ExecutionEvent] = {
     runStatus match {
-      case successStatus: Succeeded => successStatus
-        .eventList
+      case t: RunStatus.TerminalRunStatus =>
+        log.warning(s"Tried to get terminal events on a terminal status without events: $runStatus")
+        t.eventList
+
       case unknown =>
         throw new RuntimeException(s"handleExecutionSuccess not called with RunStatus.Success. Instead got $unknown")
     }

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/RunStatus.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/RunStatus.scala
@@ -19,7 +19,7 @@ sealed trait RunStatus {
 
 object RunStatus {
 
-    val log: Logger = LoggerFactory.getLogger(RunStatus.toString)
+    private val log: Logger = LoggerFactory.getLogger(RunStatus.toString)
 
 
     //def fromJobStatus(status: JobStatus.State,  eventList: Seq[ExecutionEvent] = Seq.empty): Try[RunStatus] = {
@@ -53,28 +53,30 @@ object RunStatus {
             Running
     }
 
+    sealed trait TerminalRunStatus extends RunStatus {
+        def eventList: Seq[ExecutionEvent]
+    }
+
     case object Initializing extends RunStatus {
         //def isTerminal=false
     }
     case object Running extends RunStatus {
         //def isTerminal=false
     }
-    case object Succeeded extends RunStatus {
+    case object Succeeded extends TerminalRunStatus {
+        override def eventList: Seq[ExecutionEvent] = List.empty
         //def isTerminal=true
     }
 
-    case object Failed extends RunStatus
+    case object Failed extends TerminalRunStatus {
+
+        override def eventList: Seq[ExecutionEvent] = List.empty
+    }
 
     case object DeletionInProgress extends RunStatus
 
     case object StateUnspecified extends RunStatus
     case object Unrecognized extends RunStatus
-
-    sealed trait TerminalRunStatus extends RunStatus {
-      def eventList: Seq[ExecutionEvent]
-    }
-
-
 
     //case class Succeeded(eventList: Seq[ExecutionEvent]) extends TerminalRunStatus {
 


### PR DESCRIPTION
Let's make sure that RunStatus.Succeeded and RunStatus.Failed are marked as TerminalStatus.

This prevents Cromwell from staying alive when executing a single job that fails.