### PR TITLE
Add more runnables to GCP Batch

### DIFF
--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -2,6 +2,7 @@ package cromwell.backend.google.pipelines.batch
 
 import akka.http.scaladsl.model.{ContentType, ContentTypes}
 import com.google.cloud.batch.v1.JobName
+import cromwell.backend.google.pipelines.batch.monitoring.MonitoringImage
 //import cats.syntax.validated._
 import cats.implicits._
 import com.google.cloud.storage.contrib.nio.CloudStorageOptions
@@ -567,19 +568,14 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
 
         val workflowOptions = workflowDescriptor.workflowOptions
 
-
-        /*
-        val monitoringImage =
-          new MonitoringImage(
-            jobDescriptor = jobDescriptor,
-            workflowOptions = workflowOptions,
-            workflowPaths = workflowPaths,
-            commandDirectory = commandDirectory,
-            workingDisk = workingDisk,
-            localMonitoringImageScriptPath = localMonitoringImageScriptPath,
-          )
-
-        */
+        val monitoringImage = new MonitoringImage(
+          jobDescriptor = jobDescriptor,
+          workflowOptions = workflowOptions,
+          workflowPaths = workflowPaths,
+          commandDirectory = commandDirectory,
+          workingDisk = workingDisk,
+          localMonitoringImageScriptPath = localMonitoringImageScriptPath,
+        )
 
         val checkpointingConfiguration =
           new CheckpointingConfiguration(
@@ -628,7 +624,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
           retryWithMoreMemoryKeys = retryWithMoreMemoryKeys,
           fuseEnabled = fuseEnabled(jobDescriptor.workflowDescriptor),
           referenceDisksForLocalizationOpt = referenceDisksToMount,
-          //monitoringImage = monitoringImage,
+          monitoringImage = monitoringImage,
           checkpointingConfiguration,
           enableSshAccess = enableSshAccess,
           //vpcNetworkAndSubnetworkProjectLabels = data.vpcNetworkAndSubnetworkProjectLabels,

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactory.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactory.scala
@@ -3,8 +3,9 @@ package cromwell.backend.google.pipelines.batch.api
 import com.google.cloud.batch.v1.{CreateJobRequest, GetJobRequest, JobName}
 import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.VirtualPrivateCloudConfiguration
-import cromwell.backend.google.pipelines.batch.io.GcpBatchAttachedDisk
 import cromwell.backend.google.pipelines.batch._
+import cromwell.backend.google.pipelines.batch.io.GcpBatchAttachedDisk
+import cromwell.backend.google.pipelines.batch.monitoring.MonitoringImage
 import cromwell.backend.google.pipelines.common.PipelinesApiLiteralInput
 import cromwell.backend.google.pipelines.common.monitoring.CheckpointingConfiguration
 import cromwell.core.path.Path
@@ -83,7 +84,7 @@ object GcpBatchRequestFactory {
                                       retryWithMoreMemoryKeys: Option[List[String]],
                                       fuseEnabled: Boolean,
                                       referenceDisksForLocalizationOpt: Option[List[GcpBatchAttachedDisk]],
-                                      //monitoringImage: MonitoringImage,
+                                      monitoringImage: MonitoringImage,
                                       checkpointingConfiguration: CheckpointingConfiguration,
                                       enableSshAccess: Boolean,
                                       //vpcNetworkAndSubnetworkProjectLabels: Option[VpcAndSubnetworkProjectLabelValues],

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -25,7 +25,8 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
   with UserRunnable
   with ContainerSetup
   with Localization
-  with Delocalization {
+  with Delocalization
+  with MemoryRetryCheckRunnable {
 
   override def queryRequest(jobName: JobName): GetJobRequest = GetJobRequest.newBuilder.setName(jobName.toString).build
 
@@ -173,8 +174,8 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val containerSetup: List[Runnable] = containerSetupRunnables(allVolumes)
     val localization: List[Runnable] = localizeRunnables(createParameters, allVolumes)
     val userRunnable: List[Runnable] = userRunnables(data.createParameters)
-    val memoryRetryRunnable: List[Runnable] = List.empty //checkForMemoryRetryActions(createPipelineParameters, mounts)
-    val deLocalization: List[Runnable] = deLocalizeRunnables(createParameters, allVolumes)
+    val memoryRetryRunnable: List[Runnable] = checkForMemoryRetryActions(createParameters, allVolumes)
+    val deLocalization: List[Runnable] = List.empty // deLocalizeRunnables(createParameters, allVolumes)
     val monitoringSetup: List[Runnable] = List.empty //monitoringSetupActions(createPipelineParameters, mounts)
     val monitoringShutdown: List[Runnable] = List.empty //monitoringShutdownActions(createPipelineParameters)
     val checkpointingStart: List[Runnable] = List.empty //checkpointingSetupActions(createPipelineParameters, mounts)

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -27,7 +27,8 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
   with Localization
   with Delocalization
   with MemoryRetryCheckRunnable
-  with MonitoringRunnable {
+  with MonitoringRunnable
+  with CheckpointingRunnable {
 
   override def queryRequest(jobName: JobName): GetJobRequest = GetJobRequest.newBuilder.setName(jobName.toString).build
 
@@ -179,8 +180,8 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val deLocalization: List[Runnable] = List.empty // deLocalizeRunnables(createParameters, allVolumes)
     val monitoringSetup: List[Runnable] = monitoringSetupRunnables(createParameters, allVolumes)
     val monitoringShutdown: List[Runnable] = monitoringShutdownRunnables(createParameters)
-    val checkpointingStart: List[Runnable] = List.empty //checkpointingSetupActions(createPipelineParameters, mounts)
-    val checkpointingShutdown: List[Runnable] = List.empty //checkpointingShutdownActions(createPipelineParameters)
+    val checkpointingStart: List[Runnable] = checkpointingSetupRunnables(createParameters, allVolumes)
+    val checkpointingShutdown: List[Runnable] = checkpointingShutdownRunnables(createParameters)
     val sshAccess: List[Runnable] = List.empty //sshAccessActions(createPipelineParameters, mounts)
 
     val sortedRunnables: List[Runnable] = RunnableUtils.sortRunnables(

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -26,7 +26,8 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
   with ContainerSetup
   with Localization
   with Delocalization
-  with MemoryRetryCheckRunnable {
+  with MemoryRetryCheckRunnable
+  with MonitoringRunnable {
 
   override def queryRequest(jobName: JobName): GetJobRequest = GetJobRequest.newBuilder.setName(jobName.toString).build
 
@@ -174,10 +175,10 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val containerSetup: List[Runnable] = containerSetupRunnables(allVolumes)
     val localization: List[Runnable] = localizeRunnables(createParameters, allVolumes)
     val userRunnable: List[Runnable] = userRunnables(data.createParameters)
-    val memoryRetryRunnable: List[Runnable] = checkForMemoryRetryActions(createParameters, allVolumes)
+    val memoryRetryRunnable: List[Runnable] = checkForMemoryRetryRunnables(createParameters, allVolumes)
     val deLocalization: List[Runnable] = List.empty // deLocalizeRunnables(createParameters, allVolumes)
-    val monitoringSetup: List[Runnable] = List.empty //monitoringSetupActions(createPipelineParameters, mounts)
-    val monitoringShutdown: List[Runnable] = List.empty //monitoringShutdownActions(createPipelineParameters)
+    val monitoringSetup: List[Runnable] = monitoringSetupRunnables(createParameters, allVolumes)
+    val monitoringShutdown: List[Runnable] = monitoringShutdownRunnables(createParameters)
     val checkpointingStart: List[Runnable] = List.empty //checkpointingSetupActions(createPipelineParameters, mounts)
     val checkpointingShutdown: List[Runnable] = List.empty //checkpointingShutdownActions(createPipelineParameters)
     val sshAccess: List[Runnable] = List.empty //sshAccessActions(createPipelineParameters, mounts)

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -3,7 +3,7 @@ package cromwell.backend.google.pipelines.batch.api
 import com.google.cloud.batch.v1.AllocationPolicy.Accelerator
 import com.google.cloud.batch.v1.{GetJobRequest, JobName}
 import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.GcsTransferConfiguration
-import cromwell.backend.google.pipelines.batch.runnable.{ContainerSetup, Localization, RunnableUtils, UserRunnable}
+import cromwell.backend.google.pipelines.batch.runnable._
 import cromwell.backend.google.pipelines.batch.{BatchUtilityConversions, GcpBatchRequest, RunStatus}
 import cromwell.core.WorkflowId
 
@@ -24,7 +24,8 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
   with BatchUtilityConversions
   with UserRunnable
   with ContainerSetup
-  with Localization {
+  with Localization
+  with Delocalization {
 
   override def queryRequest(jobName: JobName): GetJobRequest = GetJobRequest.newBuilder.setName(jobName.toString).build
 
@@ -173,7 +174,7 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val localization: List[Runnable] = localizeRunnables(createParameters, allVolumes)
     val userRunnable: List[Runnable] = userRunnables(data.createParameters)
     val memoryRetryRunnable: List[Runnable] = List.empty //checkForMemoryRetryActions(createPipelineParameters, mounts)
-    val deLocalization: List[Runnable] = List.empty //deLocalizeActions(createPipelineParameters, mounts)
+    val deLocalization: List[Runnable] = deLocalizeRunnables(createParameters, allVolumes)
     val monitoringSetup: List[Runnable] = List.empty //monitoringSetupActions(createPipelineParameters, mounts)
     val monitoringShutdown: List[Runnable] = List.empty //monitoringShutdownActions(createPipelineParameters)
     val checkpointingStart: List[Runnable] = List.empty //checkpointingSetupActions(createPipelineParameters, mounts)

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/monitoring/MonitoringImage.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/monitoring/MonitoringImage.scala
@@ -1,0 +1,46 @@
+package cromwell.backend.google.pipelines.batch.monitoring
+
+import cromwell.backend.BackendJobDescriptor
+import cromwell.backend.google.pipelines.batch.io.GcpBatchAttachedDisk
+import cromwell.backend.google.pipelines.batch.runnable.WorkflowOptionKeys
+import cromwell.backend.io.WorkflowPaths
+import cromwell.core.WorkflowOptions
+import cromwell.core.path.{Path, PathFactory}
+
+final class MonitoringImage(jobDescriptor: BackendJobDescriptor,
+                            workflowOptions: WorkflowOptions,
+                            workflowPaths: WorkflowPaths,
+                            commandDirectory: Path,
+                            workingDisk: GcpBatchAttachedDisk,
+                            localMonitoringImageScriptPath: Path,
+                           ) {
+
+  val monitoringImageOption: Option[String] = workflowOptions.get(WorkflowOptionKeys.MonitoringImage).toOption
+
+  val monitoringImageScriptContainerPath: Path = workingDisk.mountPoint.resolve(localMonitoringImageScriptPath)
+
+  val monitoringImageScriptOption: Option[Path] =
+    for {
+      _ <- monitoringImageOption // Only use the monitoring_image_script when monitoring_image provided
+      monitoringImageScript <- workflowOptions.get(WorkflowOptionKeys.MonitoringImageScript).toOption
+    } yield {
+      PathFactory.buildPath(
+        monitoringImageScript,
+        workflowPaths.pathBuilders,
+      )
+    }
+
+  val monitoringImageCommand: List[String] =
+    monitoringImageScriptOption match {
+      case Some(_) => List(
+        "/bin/sh",
+        "-c",
+        s"cd '${commandDirectory.pathAsString}' && " +
+          s"chmod +x '${monitoringImageScriptContainerPath.pathAsString}' && " +
+          s"'${monitoringImageScriptContainerPath.pathAsString}'"
+      )
+      case None => Nil
+    }
+
+//  val monitoringImageEnvironment: MountsToEnv = Env.monitoringImageEnvironment(jobDescriptor)
+}

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/Delocalization.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/Delocalization.scala
@@ -1,0 +1,146 @@
+package cromwell.backend.google.pipelines.batch.runnable
+
+import com.google.cloud.batch.v1.{Runnable, Volume}
+import common.util.StringUtil._
+import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.GcsTransferConfiguration
+import cromwell.backend.google.pipelines.batch.GcpBatchJobPaths.GcsDelocalizationScriptName
+import cromwell.backend.google.pipelines.batch.GcpBatchParameterConversions._
+import cromwell.backend.google.pipelines.batch.ToParameter.ops._
+import cromwell.backend.google.pipelines.batch.api.GcpBatchRequestFactory.CreatePipelineParameters
+import cromwell.backend.google.pipelines.batch._
+import cromwell.core.path.{DefaultPathBuilder, Path}
+import wom.runtime.WomOutputRuntimeExtractor
+
+import java.util.UUID
+import scala.concurrent.duration._
+
+trait Delocalization {
+
+  import RunnableBuilder._
+  import RunnableCommands._
+  import RunnableLabels._
+  import RunnableUtils._
+
+  private def delocalizeLogsRunnable(gcsLogPath: Path)(implicit gcsTransferConfiguration: GcsTransferConfiguration) = {
+    cloudSdkShellRunnable(
+      delocalizeDirectory(DefaultPathBuilder.build(logsRoot).get, gcsLogPath, GcpBatchAsyncBackendJobExecutionActor.plainTextContentType)
+    )(labels = Map(Key.Tag -> Value.Delocalization))
+      .withAlwaysRun(true)
+  }
+
+  // Used for the final copy of the logs to make sure we have the most up to date version before terminating the job
+  private def copyAggregatedLogToLegacyPath(gcsLegacyLogPath: Path)
+                                           (implicit gcsTransferConfiguration: GcsTransferConfiguration): Runnable.Builder = {
+    cloudSdkShellRunnable(
+      delocalizeFileTo(DefaultPathBuilder.build(aggregatedLog).get, gcsLegacyLogPath, GcpBatchAsyncBackendJobExecutionActor.plainTextContentType)
+    )(labels = Map(Key.Tag -> Value.Delocalization)).withAlwaysRun(true)
+  }
+
+  // Periodically copies the logs out to GCS
+  private def copyAggregatedLogToLegacyPathPeriodic(gcsLegacyLogPath: Path)
+                                                   (implicit gcsTransferConfiguration: GcsTransferConfiguration): Runnable.Builder = {
+    cloudSdkShellRunnable(
+      every(30.seconds) { delocalizeFileTo(DefaultPathBuilder.build(aggregatedLog).get, gcsLegacyLogPath, GcpBatchAsyncBackendJobExecutionActor.plainTextContentType) }
+    )(labels = Map(Key.Tag -> Value.Background))
+      .withRunInBackground(true)
+  }
+
+  private def runtimeOutputExtractorRunnable(containerCallRoot: String,
+                                           outputFile: String,
+                                           womOutputRuntimeExtractor: WomOutputRuntimeExtractor): Runnable.Builder = {
+    val commands = List(
+      "-c",
+      // Create the directory where the fofn will be written
+      s"mkdir -p $$(dirname $outputFile) && " +
+        s"cd $containerCallRoot && " +
+        """echo "Runtime output files to be delocalized:" && """ +
+        s"${womOutputRuntimeExtractor.command} | tee $outputFile"
+    )
+
+    RunnableBuilder
+      .withImage(womOutputRuntimeExtractor.dockerImage.getOrElse(CloudSdkImage))
+      .withCommand(commands: _*) // TODO: Both calls likely need to be together
+      .withEntrypointCommand("/bin/bash")
+      // Saves us some time if something else fails before we get to run this runnable
+//      .withDisableImagePrefetch(true)
+//      .withLabels(Map(Key.Tag -> Value.Delocalization))
+  }
+
+  private def delocalizeRuntimeOutputsScript(fofnPath: String, workflowRoot: Path, cloudCallRoot: Path)(implicit gcsTransferConfiguration: GcsTransferConfiguration) = {
+    val gsutilCommand: String => String = { flag =>
+      s"""rm -f $$HOME/.config/gcloud/gce && gsutil -m $flag cp -r $$line "${cloudCallRoot.pathAsString.ensureSlashed}$$gcs_path""""
+    }
+
+    def sedStripPrefix(prefix: String) = s"""sed -e "s/^${prefix.ensureSedEscaped}//""""
+
+    // See RuntimeOutputMapping.prefixFilters for more info on why this is needed
+    val prefixFilters = RuntimeOutputMapping
+      .prefixFilters(workflowRoot)
+      .map(sedStripPrefix)
+      .mkString(" | ")
+
+    /*
+     * Delocalize all the files returned by the runtime output extractor
+     */
+    s"""|#!/bin/bash
+        |
+        |set -x
+        |
+        |if [ -f $fofnPath ]; then
+        |  while IFS= read line
+        |  do
+        |    gcs_path=$$(echo $$line | $prefixFilters)
+        |    (
+        |       ${retry(recoverRequesterPaysError(cloudCallRoot)(gsutilCommand))}
+        |    )
+        |  done  <$fofnPath
+        |fi""".stripMargin
+  }
+
+  private def delocalizeRuntimeOutputsRunnable(cloudCallRoot: Path, inputFile: String, workflowRoot: Path)(implicit gcsTransferConfiguration: GcsTransferConfiguration): Runnable.Builder = {
+    val command = multiLineCommand(delocalizeRuntimeOutputsScript(inputFile, workflowRoot, cloudCallRoot))
+    RunnableBuilder.cloudSdkShellRunnable(command)(labels = Map(Key.Tag -> Value.Delocalization))
+//      .withDisableImagePrefetch(true)
+  }
+
+  def deLocalizeRunnables(createPipelineParameters: CreatePipelineParameters,
+                          volumes: List[Volume])(implicit gcsTransferConfiguration: GcsTransferConfiguration): List[Runnable] = {
+    val cloudCallRoot = createPipelineParameters.cloudCallRoot
+    val callExecutionContainerRoot = createPipelineParameters.commandScriptContainerPath.parent
+
+    // TODO: Consider renaming to batch-logs, find where this is created
+    val gcsLogDirectoryPath = createPipelineParameters.cloudCallRoot / "pipelines-logs"
+    val gcsLegacyLogPath = createPipelineParameters.logGcsPath
+
+    /*
+     * Ideally temporaryFofnForRuntimeOutputFiles should be somewhere else than the execution directory (we could mount anther directory)
+     * However because it runs after everything else there's no risk of polluting the task's results and the random ID ensures we don't override anything
+     */
+    val temporaryFofnDirectoryForRuntimeOutputFiles = callExecutionContainerRoot.pathAsString.ensureSlashed + UUID.randomUUID().toString.split("-")(0)
+    val temporaryFofnForRuntimeOutputFiles = temporaryFofnDirectoryForRuntimeOutputFiles + "/runtime_output_files.txt"
+
+    val runtimeExtractionRunnables = createPipelineParameters.womOutputRuntimeExtractor.toList flatMap { extractor =>
+      List (
+        runtimeOutputExtractorRunnable(callExecutionContainerRoot.pathAsString, temporaryFofnForRuntimeOutputFiles, extractor),
+        delocalizeRuntimeOutputsRunnable(cloudCallRoot, temporaryFofnForRuntimeOutputFiles, createPipelineParameters.cloudWorkflowRoot)
+      )
+    }
+
+    val gcsDelocalizationContainerPath = createPipelineParameters.commandScriptContainerPath.sibling(GcsDelocalizationScriptName)
+
+    val delocalizationLabel = Map(Key.Tag -> Value.Delocalization)
+    val runGcsDelocalizationScript = cloudSdkShellRunnable(
+      s"/bin/bash $gcsDelocalizationContainerPath")(labels = delocalizationLabel)
+
+    val annotatedRunnables: List[Runnable.Builder] = runGcsDelocalizationScript ::
+      createPipelineParameters.outputParameters.flatMap(_.toRunnables(volumes)) ++
+        runtimeExtractionRunnables
+
+    (RunnableBuilder.annotateTimestampedRunnable("delocalization", Value.Delocalization)(
+      annotatedRunnables
+    ) :+
+      copyAggregatedLogToLegacyPath(gcsLegacyLogPath) :+
+      copyAggregatedLogToLegacyPathPeriodic(gcsLegacyLogPath) :+
+      delocalizeLogsRunnable(gcsLogDirectoryPath)).map(_.build)
+  }
+}

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/Localization.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/Localization.scala
@@ -58,7 +58,7 @@ trait Localization {
     } else List[Runnable.Builder]()
 
     // Any "classic" PAPI v2 one-at-a-time localizations for non-GCS inputs.
-    val singletonLocalizations = createPipelineParameters.inputOutputParameters.fileInputParameters.flatMap(_.toRunnables(volumes).toList)
+    val singletonLocalizations = createPipelineParameters.inputOutputParameters.fileInputParameters.flatMap(_.toRunnables(volumes))
 
     val localizations =
       localizeGcsTransferLibrary ::

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/MemoryRetryCheckRunnable.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/MemoryRetryCheckRunnable.scala
@@ -5,7 +5,7 @@ import cromwell.backend.google.pipelines.batch.api.GcpBatchRequestFactory.Create
 
 trait MemoryRetryCheckRunnable {
 
-  def checkForMemoryRetryActions(createPipelineParameters: CreatePipelineParameters, mounts: List[Volume]): List[Runnable] = {
+  def checkForMemoryRetryRunnables(createPipelineParameters: CreatePipelineParameters, mounts: List[Volume]): List[Runnable] = {
     createPipelineParameters.retryWithMoreMemoryKeys match {
       case Some(keys) => List(RunnableBuilder.checkForMemoryRetryRunnable(keys)).map(_.build)
       case None => List.empty[Runnable]

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/MemoryRetryCheckRunnable.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/MemoryRetryCheckRunnable.scala
@@ -1,0 +1,14 @@
+package cromwell.backend.google.pipelines.batch.runnable
+
+import com.google.cloud.batch.v1.{Runnable, Volume}
+import cromwell.backend.google.pipelines.batch.api.GcpBatchRequestFactory.CreatePipelineParameters
+
+trait MemoryRetryCheckRunnable {
+
+  def checkForMemoryRetryActions(createPipelineParameters: CreatePipelineParameters, mounts: List[Volume]): List[Runnable] = {
+    createPipelineParameters.retryWithMoreMemoryKeys match {
+      case Some(keys) => List(RunnableBuilder.checkForMemoryRetryRunnable(keys)).map(_.build)
+      case None => List.empty[Runnable]
+    }
+  }
+}

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/MonitoringRunnable.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/MonitoringRunnable.scala
@@ -1,0 +1,64 @@
+package cromwell.backend.google.pipelines.batch.runnable
+
+import com.google.cloud.batch.v1.{Runnable, Volume}
+import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.GcsTransferConfiguration
+import cromwell.backend.google.pipelines.batch.api.GcpBatchRequestFactory.CreatePipelineParameters
+
+trait MonitoringRunnable {
+  def monitoringSetupRunnables(createParameters: CreatePipelineParameters,
+                             mounts: List[Volume]
+                            )(implicit gcsTransferConfiguration: GcsTransferConfiguration): List[Runnable] = {
+
+    val monitoringImageScriptRunnables =
+      createParameters.monitoringImage.monitoringImageScriptOption match {
+        case Some(script) =>
+          val localizeScriptRunnable =
+            RunnableBuilder.monitoringImageScriptRunnable(
+              script,
+              createParameters.monitoringImage.monitoringImageScriptContainerPath,
+            )
+          val describeLocalizeScriptRunnable =
+            RunnableBuilder.describeDocker(
+              "localizing monitoring image script runnable",
+              localizeScriptRunnable,
+            )
+          List(describeLocalizeScriptRunnable, localizeScriptRunnable)
+        case None => Nil
+      }
+
+    val monitoringImageRunnables =
+      createParameters.monitoringImage.monitoringImageOption match {
+        case Some(image) =>
+
+          val monitoringImage = image
+          val monitoringImageCommand = createParameters.monitoringImage.monitoringImageCommand
+//          val monitoringImageEnvironment = createParameters.monitoringImage.monitoringImageEnvironment
+
+          val monitoringRunnable = RunnableBuilder.backgroundRunnable(
+            monitoringImage,
+            monitoringImageCommand,
+//            monitoringImageEnvironment(mounts.map(_.getPath)),
+          )
+
+          val describeMonitoringRunnable = RunnableBuilder.describeDocker("monitoring runnable", monitoringRunnable)
+
+          List(describeMonitoringRunnable, monitoringRunnable)
+
+        case None => Nil
+      }
+
+    (monitoringImageScriptRunnables ++ monitoringImageRunnables).map(_.build)
+  }
+
+  def monitoringShutdownRunnables(createParameters: CreatePipelineParameters): List[Runnable] = {
+    createParameters.monitoringImage.monitoringImageOption match {
+      case Some(_) =>
+        val terminationRunnable = RunnableBuilder.terminateBackgroundRunnablesRunnable()
+
+        val describeTerminationRunnable = RunnableBuilder.describeDocker("terminate monitoring runnable", terminationRunnable)
+
+        List(describeTerminationRunnable, terminationRunnable).map(_.build)
+      case None => Nil
+    }
+  }
+}

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
@@ -90,6 +90,13 @@ object RunnableBuilder {
 //      .setPidNamespace(backgroundActionPidNamespace)
   }
 
+  def gcsFileDeletionRunnable(cloudPath: String): Runnable.Builder = {
+    cloudSdkShellRunnable(
+      s"""gsutil rm '$cloudPath'"""
+    )(labels = Map(Key.Tag -> Value.Monitoring))
+//      .withIgnoreExitStatus(true)
+  }
+
   //privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken],
   //fuseEnabled: Boolean)
   def userRunnable(docker: String,

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
@@ -2,7 +2,9 @@ package cromwell.backend.google.pipelines.batch.runnable
 
 import com.google.cloud.batch.v1.Runnable
 import com.google.cloud.batch.v1.Runnable.Container
+import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.GcsTransferConfiguration
 import cromwell.backend.google.pipelines.batch.{BatchParameter, GcpBatchInput, GcpBatchOutput}
+import cromwell.core.path.Path
 
 import scala.jdk.CollectionConverters._
 
@@ -61,6 +63,33 @@ object RunnableBuilder {
 
   private def cloudSdkContainerBuilder: Container.Builder = Container.newBuilder.setImageUri(CloudSdkImage)
 
+  def monitoringImageScriptRunnable(cloudPath: Path, containerPath: Path)
+                                 (implicit gcsTransferConfiguration: GcsTransferConfiguration): Runnable.Builder = {
+    val command = RunnableCommands.localizeFile(cloudPath, containerPath)
+    val labels = Map(Key.Tag -> Value.Localization)
+    cloudSdkShellRunnable(command)(labels = labels)
+  }
+
+  def backgroundRunnable(image: String,
+                       command: List[String],
+//                       environment: Map[String, String],
+                      ): Runnable.Builder = {
+    withImage(image)
+      .withEntrypointCommand(command: _*)
+      .withRunInBackground(true)
+//      .withIgnoreExitStatus(true)
+//      .setEnvironment(environment.asJava)
+//      .withLabels(Map(Key.Tag -> Value.Monitoring))
+//      .setPidNamespace(backgroundActionPidNamespace)
+  }
+
+
+  def terminateBackgroundRunnablesRunnable(): Runnable.Builder = {
+    cloudSdkShellRunnable(terminateAllBackgroundRunnablesCommand)(labels = Map(Key.Tag -> Value.Monitoring))
+      .withAlwaysRun(true)
+//      .setPidNamespace(backgroundActionPidNamespace)
+  }
+
   //privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken],
   //fuseEnabled: Boolean)
   def userRunnable(docker: String,
@@ -94,11 +123,11 @@ object RunnableBuilder {
 
   //  Needs label support
   // Creates a Runnable that logs the docker command for the passed in runnable.
-  def describeDocker(description: String, runnable: Runnable): Runnable = {
+  def describeDocker(description: String, runnable: Runnable.Builder): Runnable.Builder = {
     logTimestampedRunnable(
-      s"Running $description: ${RunnableBuilder.toDockerRun(runnable)}",
+      s"Running $description: ${toDockerRun(runnable)}",
       Map.empty
-    ).build()
+    )
   }
 
   private def timestampedMessage(message: String): String =
@@ -172,7 +201,7 @@ object RunnableBuilder {
   }
 
   // Converts an Runnable to a `docker run ...` command runnable in the shell.
-  private[runnable] def toDockerRun(runnable: Runnable): String = {
+  private[runnable] def toDockerRun(runnable: Runnable.Builder): String = {
     runnable.getContainer
       .getCommandsList
       .asScala

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
@@ -85,6 +85,12 @@ object RunnableBuilder {
     //.withTimeout(timeout)
   }
 
+  def checkForMemoryRetryRunnable(retryLookupKeys: List[String]): Runnable.Builder = {
+    cloudSdkShellRunnable(RunnableCommands.checkIfStderrContainsRetryKeys(retryLookupKeys))(
+      labels = Map(Key.Tag -> Value.RetryWithMoreMemory)
+    )
+      .withAlwaysRun(true)
+  }
 
   //  Needs label support
   // Creates a Runnable that logs the docker command for the passed in runnable.

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableUtils.scala
@@ -93,9 +93,9 @@ object RunnableUtils {
                             isBackground: Runnable => Boolean,
                          ): List[Runnable] = {
     val toBeSortedRunnables = localization ++ userRunnable ++ memoryRetryRunnable ++ deLocalization
-    val sortedRunnables = toBeSortedRunnables.sortWith({
+    val sortedRunnables = toBeSortedRunnables.sortWith {
       case (runnable, _) => isBackground(runnable)
-    })
+    }
 
     sshAccess ++ containerSetup ++ monitoringSetup ++ checkpointingStart ++ sortedRunnables ++ checkpointingShutdown ++ monitoringShutdown
   }

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/UserRunnable.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/UserRunnable.scala
@@ -18,7 +18,7 @@ trait UserRunnable {
       //createPipelineParameters.fuseEnabled
     )
 
-    val describeAction = RunnableBuilder.describeDocker("user action", userRunnable.build)
-    List(describeAction, userRunnable.build)
+    val describeRunnable = RunnableBuilder.describeDocker("user runnable", userRunnable)
+    List(describeRunnable, userRunnable).map(_.build)
   }
 }


### PR DESCRIPTION
- Add Delocalize (pending to enable).
- Add MemoryRetryCheck.
- Add Monitoring.
- Add Checkpointing.

While the workflow succeeds, it is ideal to do extra checks and fix issues if necessary.