### PR TITLE
Fix cromwell_root/script execution issues

### DIFF
--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -134,10 +134,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   import GcpBatchAsyncBackendJobExecutionActor._
   override lazy val ioCommandBuilder: IoCommandBuilder = GcsBatchCommandBuilder
 
-  lazy val gcpBatchCommand: String = jobDescriptor.taskCall.callable.commandTemplateString(Map.empty)
   lazy val workflowId: WorkflowId = jobDescriptor.workflowDescriptor.id
-  //lazy val gcpBootDiskSizeGb = runtimeAttributes.bootDiskSize
-  //println(f"$gcpBootDiskSizeGb LOOOOOOOOOOOK")
 
   /** The type of the run info when a job is started. */
   override type StandardAsyncRunInfo = Run
@@ -626,10 +623,9 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
           referenceDisksForLocalizationOpt = referenceDisksToMount,
           monitoringImage = monitoringImage,
           checkpointingConfiguration,
-          enableSshAccess = enableSshAccess,
+          enableSshAccess = enableSshAccess
           //vpcNetworkAndSubnetworkProjectLabels = data.vpcNetworkAndSubnetworkProjectLabels,
           //dockerImageCacheDiskOpt = isDockerImageCacheUsageRequested.option(dockerImageCacheDiskOpt).flatten
-          gcpBatchCommand = gcpBatchCommand
         )
       case Some(other) =>
         throw new RuntimeException(s"Unexpected initialization data: $other")
@@ -794,6 +790,8 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       contentType = plainTextContentType)
   }
 
+  override lazy val commandDirectory: Path = GcpBatchWorkingDisk.MountPoint
+
 
   // Primary entry point for cromwell to run GCP Batch job
   override def executeAsync(): Future[ExecutionHandle] = {
@@ -873,7 +871,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       //_ = this.hasDockerCredentials = createParameters.privateDockerKeyAndEncryptedToken.isDefined
       //_ <- uploadGcsTransferLibrary(createParameters, gcsTransferLibraryCloudPath, gcsTransferConfiguration)
       jobName = "job-" + java.util.UUID.randomUUID.toString
-      request = GcpBatchRequest(workflowId, createParameters, jobName = jobName, gcpBatchCommand, gcpBatchParameters)
+      request = GcpBatchRequest(workflowId, createParameters, jobName = jobName, gcpBatchParameters)
       response <- runPipeline(request = request, backendSingletonActor = backendSingletonActor)
     } yield response
 

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchRequest.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchRequest.scala
@@ -6,5 +6,4 @@ import cromwell.core.WorkflowId
 case class GcpBatchRequest(workflowId: WorkflowId,
                            createParameters: CreatePipelineParameters,
                            jobName: String,
-                           gcpBatchCommand: String,
                            gcpBatchParameters: CreateGcpBatchParameters)

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactory.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactory.scala
@@ -86,10 +86,9 @@ object GcpBatchRequestFactory {
                                       referenceDisksForLocalizationOpt: Option[List[GcpBatchAttachedDisk]],
                                       monitoringImage: MonitoringImage,
                                       checkpointingConfiguration: CheckpointingConfiguration,
-                                      enableSshAccess: Boolean,
+                                      enableSshAccess: Boolean
                                       //vpcNetworkAndSubnetworkProjectLabels: Option[VpcAndSubnetworkProjectLabelValues],
                                       //dockerImageCacheDiskOpt: Option[String]
-                                      gcpBatchCommand: String // TODO: Alex - verify whether we actually need this
                                      ) {
     def literalInputs = inputOutputParameters.literalInputParameters
 

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -154,7 +154,7 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
 
     println(f"command script container path ${data.createParameters.commandScriptContainerPath}")
     println(f"cloud workflow root ${data.createParameters.cloudWorkflowRoot}")
-    println(f"all parameters ${data.createParameters.allParameters}")
+    println(f"all parameters:\n ${data.createParameters.allParameters.mkString("\n")}")
 
     // parse preemption value and set value for Spot. Spot is replacement for preemptible
     val spotModel = toProvisioningModel(runtimeAttributes.preemptible)
@@ -177,7 +177,7 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val localization: List[Runnable] = localizeRunnables(createParameters, allVolumes)
     val userRunnable: List[Runnable] = userRunnables(data.createParameters)
     val memoryRetryRunnable: List[Runnable] = checkForMemoryRetryRunnables(createParameters, allVolumes)
-    val deLocalization: List[Runnable] = List.empty // deLocalizeRunnables(createParameters, allVolumes)
+    val deLocalization: List[Runnable] = deLocalizeRunnables(createParameters, allVolumes)
     val monitoringSetup: List[Runnable] = monitoringSetupRunnables(createParameters, allVolumes)
     val monitoringShutdown: List[Runnable] = monitoringShutdownRunnables(createParameters)
     val checkpointingStart: List[Runnable] = checkpointingSetupRunnables(createParameters, allVolumes)

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableBuilder.scala
@@ -100,7 +100,7 @@ object RunnableBuilder {
   //privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken],
   //fuseEnabled: Boolean)
   def userRunnable(docker: String,
-                   command: String,
+                   scriptContainerPath: String,
                    jobShell: String): Runnable.Builder = {
 
 //    val dockerImageIdentifier = DockerImageIdentifier.fromString(docker)
@@ -114,8 +114,7 @@ object RunnableBuilder {
     val container = Container.newBuilder
       .setImageUri(docker)
       .setEntrypoint(jobShell)
-      .addCommands("-c") // TODO: Verify whether this is still required
-      .addCommands(command)
+      .addCommands(scriptContainerPath)
     Runnable.newBuilder().setContainer(container)
     //.withLabels(labels)
     //.withTimeout(timeout)

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/UserRunnable.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/UserRunnable.scala
@@ -9,9 +9,7 @@ trait UserRunnable {
   def userRunnables(createPipelineParameters: CreatePipelineParameters): List[Runnable] = {
     val userRunnable = RunnableBuilder.userRunnable(
       docker = createPipelineParameters.dockerImage,
-      // TODO: Alex - This used to be createPipelineParameters.commandScriptContainerPath.pathAsString which is /cromwell_root/script
-      // I'm not sure if such a script will include the value from gcpBatchCommand
-      command = createPipelineParameters.gcpBatchCommand,
+      scriptContainerPath = createPipelineParameters.commandScriptContainerPath.pathAsString,
       jobShell = createPipelineParameters.jobShell,
       // not necessary for now
       //createPipelineParameters.privateDockerKeyAndEncryptedToken,


### PR DESCRIPTION
This script wasn't being executed because it was disabled to avoid the volume mounting issue (fixed by #56).

There was another uncovered problem, the script content was trying to deal with gcp files instead of the local file system, which is solved now.

Let's enable the script execution so that delocalization works.

NOTE: The delocalization steps involving `/google` are disabled.