### PR TITLE
GCP Batch delocalization improvements

### DIFF
--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/runnable/RunnableUtils.scala
@@ -54,12 +54,6 @@ object RunnableUtils {
     StringEscapeUtils.escapeXSI(str)
   }
 
-  /** Cloud Life Sciences / Genomics Pipelines API logs directory. */
-  val logsRoot = "/google/logs"
-
-  /** Cloud Life Sciences / Genomics Pipelines API logs file. */
-  val aggregatedLog = s"$logsRoot/output"
-
   /**
     * Define a shared PID namespace for background runnable containers and their termination controller.
     * The value is "monitoring" for historical (first usage) reasons.


### PR DESCRIPTION
Turns out that we don't need to deal with /google directory which is specific to lifesciences, those logs are already exported to cloud logging.

See https://cloud.google.com/life-sciences/docs/reference/rpc/google.cloud.lifesciences.v2beta