### PR TITLE
GCP Batch abort job implementation

### DIFF
--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/BatchApiAbortClient.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/BatchApiAbortClient.scala
@@ -1,0 +1,20 @@
+package cromwell.backend.google.pipelines.batch
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import com.google.cloud.batch.v1.JobName
+
+trait BatchApiAbortClient { this: Actor with ActorLogging =>
+
+  def abortJob(jobName: JobName, backendSingletonActor: ActorRef): Unit = {
+    backendSingletonActor ! GcpBatchBackendSingletonActor.Action.AbortJob(jobName)
+  }
+
+  def abortActorClientReceive: Actor.Receive = {
+    case GcpBatchBackendSingletonActor.Event.JobAbortRequestSent(job) =>
+      log.info(s"Job aborted on GCP: ${job.getName}")
+
+    case GcpBatchBackendSingletonActor.Event.ActionFailed(jobName, cause) =>
+      val msg = s"Failed to abort job ($jobName) from GCP"
+      log.error(cause, msg)
+  }
+}

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/BatchApiRunCreationClient.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/BatchApiRunCreationClient.scala
@@ -36,7 +36,6 @@ trait BatchApiRunCreationClient { this: Actor with ActorLogging =>
       case Some(p) =>
         p.future
       case None =>
-        // TODO: Alex - I believe we can skip the singleton actor and submit the job directly
         log.info(s"Asking singleton actor to submit a job: ${request.jobName}")
         backendSingletonActor ! GcpBatchBackendSingletonActor.Action.SubmitJob(request)
         val newPromise = Promise[StandardAsyncJob]()

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchApiRequestHandler.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchApiRequestHandler.scala
@@ -3,6 +3,7 @@ package cromwell.backend.google.pipelines.batch
 import com.google.api.gax.rpc.FixedHeaderProvider
 import com.google.cloud.batch.v1._
 import com.google.common.collect.ImmutableMap
+import com.google.longrunning.Operation
 
 class GcpBatchApiRequestHandler {
   def submit(request: CreateJobRequest): Job = withClient { client =>
@@ -12,6 +13,10 @@ class GcpBatchApiRequestHandler {
 
   def query(request: GetJobRequest): Job = withClient { client =>
     client.getJob(request)
+  }
+
+  def abort(request: DeleteJobRequest): Operation = withClient { client =>
+    client.deleteJobCallable().call(request)
   }
 
   private def withClient[T](f: BatchServiceClient => T): T = {

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -126,6 +126,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     with StandardAsyncExecutionActor
     with BatchApiRunCreationClient
     with BatchApiFetchJobClient
+    with BatchApiAbortClient
     with AskSupport
     with GcpBatchJobCachingActorHelper
     with GcpBatchReferenceFilesMappingOperations
@@ -142,7 +143,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   /** The type of the run status returned during each poll. */
   override type StandardAsyncRunState = RunStatus
 
-  override def receive: Receive = runCreationClientReceive orElse pollingActorClientReceive orElse kvClientReceive orElse super.receive
+  override def receive: Receive = runCreationClientReceive orElse pollingActorClientReceive orElse abortActorClientReceive orElse kvClientReceive orElse super.receive
 
   /** Should return true if the status contained in `thiz` is equivalent to `that`, delta any other data that might be carried around
     * in the state type.
@@ -166,6 +167,9 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     case Valid(PreviousRetryReasons(p, _)) => p < maxPreemption
     case _ => false
   }
+
+  override def tryAbort(job: StandardAsyncJob): Unit = abortJob(JobName.parse(job.jobId), backendSingletonActor)
+
   //private var hasDockerCredentials: Boolean = false
 
   //type GcpBatchPendingExecutionHandle = PendingExecutionHandle[StandardAsyncJob, Run, StandardAsyncRunState]

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchBackendSingletonActor.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/GcpBatchBackendSingletonActor.scala
@@ -2,6 +2,7 @@ package cromwell.backend.google.pipelines.batch
 
 import akka.actor.{Actor, ActorLogging, Props}
 import com.google.cloud.batch.v1.JobName
+import com.google.longrunning.Operation
 import cromwell.backend.BackendSingletonActorAbortWorkflow
 import cromwell.backend.google.pipelines.batch.api.GcpBatchRequestFactory
 import cromwell.core.Dispatcher.BackendDispatcher
@@ -10,14 +11,17 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 object GcpBatchBackendSingletonActor {
-  def props(requestFactory: GcpBatchRequestFactory)(implicit requestHandler: GcpBatchApiRequestHandler) = Props(new GcpBatchBackendSingletonActor(requestFactory))
-    .withDispatcher(BackendDispatcher)
+  def props(requestFactory: GcpBatchRequestFactory)(implicit requestHandler: GcpBatchApiRequestHandler): Props = {
+    Props(new GcpBatchBackendSingletonActor(requestFactory))
+      .withDispatcher(BackendDispatcher)
+  }
 
   // This is the only type of messages that can be processed by this actor from this actor
   sealed trait Action extends Product with Serializable
   object Action {
     final case class SubmitJob(request: GcpBatchRequest) extends Action
     final case class QueryJob(jobName: JobName) extends Action
+    final case class AbortJob(jobName: JobName) extends Action
   }
 
   // This is the only type of messages produced from this actor while reacting to received messages
@@ -25,6 +29,7 @@ object GcpBatchBackendSingletonActor {
   object Event {
     final case class JobSubmitted(job: com.google.cloud.batch.v1.Job) extends Event
     final case class JobStatusRetrieved(job: com.google.cloud.batch.v1.Job) extends Event
+    final case class JobAbortRequestSent(operation: Operation) extends Event
     final case class ActionFailed(jobName: String, cause: Throwable) extends Event
   }
 
@@ -37,13 +42,12 @@ final class GcpBatchBackendSingletonActor(requestFactory: GcpBatchRequestFactory
 
   implicit val ec: ExecutionContext = context.dispatcher
 
-  // TODO: Alex - Find the usefulness for the actor because we are not holding any mutable state in it
   override def receive: Receive = {
     case Action.SubmitJob(request) =>
       val replyTo = sender()
       log.info(s"Submitting job (${request.jobName}) to GCP, workflowId = ${request.workflowId}")
       Future {
-        // TODO: Alex - Consider not hardcoding machineType
+        // TODO: Consider not hardcoding machineType
         requestHandler.submit(requestFactory.submitRequest("e2-medium", request))
       }.onComplete {
         case Failure(exception) =>
@@ -62,7 +66,7 @@ final class GcpBatchBackendSingletonActor(requestFactory: GcpBatchRequestFactory
         requestHandler.query(requestFactory.queryRequest(jobName))
       }.onComplete {
         case Success(job) =>
-          log.info(s"Job status ($jobName) retrieved from GCP, state = ${job.getStatus.getState}")
+          log.info(s"Job ($jobName) retrieved from GCP, state = ${job.getStatus.getState}")
           replyTo ! Event.JobStatusRetrieved(job)
 
         case Failure(exception) =>
@@ -70,9 +74,27 @@ final class GcpBatchBackendSingletonActor(requestFactory: GcpBatchRequestFactory
           replyTo ! Event.ActionFailed(jobName.toString ,exception)
       }
 
+    case Action.AbortJob(jobName) =>
+      val replyTo = sender()
+
+      Future {
+        requestHandler.abort(requestFactory.abortRequest(jobName))
+      }.onComplete {
+        case Success(operation) =>
+          log.info(s"Job ($jobName) aborted from GCP")
+          replyTo ! Event.JobAbortRequestSent(operation)
+
+        case Failure(exception) =>
+          log.error(exception, s"Failed to abort job ($jobName) from GCP")
+          replyTo ! Event.ActionFailed(jobName.toString, exception)
+      }
+
     // Cromwell sends this message
     case BackendSingletonActorAbortWorkflow(workflowId) =>
-      // TODO: Alex - how do we handle this?
+      // It seems that AbortJob(jobName) is processed before this message, hence, we don't need to do anything else.
+      // If it ever becomes necessary, we'll need to create link submitted jobs to its workflow id, which require
+      // us to be cautious because batch deletes jobs instead of canceling them, hence, we should not delete jobs
+      // that are on a final state.
       log.info(s"Cromwell requested to abort workflow $workflowId")
   }
 }

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactory.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactory.scala
@@ -1,6 +1,6 @@
 package cromwell.backend.google.pipelines.batch.api
 
-import com.google.cloud.batch.v1.{CreateJobRequest, GetJobRequest, JobName}
+import com.google.cloud.batch.v1.{CreateJobRequest, DeleteJobRequest, GetJobRequest, JobName}
 import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.VirtualPrivateCloudConfiguration
 import cromwell.backend.google.pipelines.batch._
@@ -17,6 +17,8 @@ trait GcpBatchRequestFactory {
   def submitRequest(machineType: String, data: GcpBatchRequest): CreateJobRequest
 
   def queryRequest(jobName: JobName): GetJobRequest
+
+  def abortRequest(jobName: JobName): DeleteJobRequest
 
 }
 

--- a/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/pipelines/batch/src/main/scala/cromwell/backend/google/pipelines/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -1,10 +1,10 @@
 package cromwell.backend.google.pipelines.batch.api
 
 import com.google.cloud.batch.v1.AllocationPolicy.Accelerator
-import com.google.cloud.batch.v1.{GetJobRequest, JobName}
+import com.google.cloud.batch.v1.{DeleteJobRequest, GetJobRequest, JobName}
 import cromwell.backend.google.pipelines.batch.GcpBatchConfigurationAttributes.GcsTransferConfiguration
 import cromwell.backend.google.pipelines.batch.runnable._
-import cromwell.backend.google.pipelines.batch.{BatchUtilityConversions, GcpBatchRequest, RunStatus}
+import cromwell.backend.google.pipelines.batch.{BatchUtilityConversions, GcpBatchRequest}
 import cromwell.core.WorkflowId
 
 //import com.google.cloud.batch.v1.AllocationPolicy._
@@ -16,7 +16,6 @@ import com.google.cloud.batch.v1.LogsPolicy.Destination
 import com.google.cloud.batch.v1.Volume
 import com.google.protobuf.Duration
 import cromwell.backend.google.pipelines.batch.io.GcpBatchAttachedDisk
-import org.slf4j.{Logger, LoggerFactory}
 
 import scala.jdk.CollectionConverters._
 
@@ -32,7 +31,7 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
 
   override def queryRequest(jobName: JobName): GetJobRequest = GetJobRequest.newBuilder.setName(jobName.toString).build
 
-  val log: Logger = LoggerFactory.getLogger(RunStatus.toString)
+  override def abortRequest(jobName: JobName): DeleteJobRequest = DeleteJobRequest.newBuilder.setName(jobName.toString).build()
 
   // VALUES HERE
   private val durationInSeconds: Long = 3600


### PR DESCRIPTION
There are two ways for handling the abort requests:

1. `GcpBatchAsyncBackendJobExecutionActor#tryAbort` gets invoked by Cromwell, in this case, we have the job id available which is used to invoke GCP, asking it to delete the job.
2. Cromwell sends the `BackendSingletonActorAbortWorkflow(workflowId)` message.  This case seems to be Cromwell's last resource for aborting a jobs and it seems to be executed after the previous case is handled. This only has the `workflowId` which is not enough to invoke GCP delete api, given that the previous case already deleted the jobs, we are not doing anything in this case. Supporting this case would involve more complexity because we'll need to keep a state to derive the job id linked to a workflow id, also, we'd need to make sure to not delete jobs that are in a final state.